### PR TITLE
Workaround limitation of 20 DB Parameters

### DIFF
--- a/ecs_composex/rds/rds_parameter_groups_helper.py
+++ b/ecs_composex/rds/rds_parameter_groups_helper.py
@@ -34,6 +34,9 @@ def get_db_cluster_engine_parameter_group_defaults(engine_family):
                 and "{" not in param["ParameterValue"]
                 and "IsModifiable" in param.keys()
                 and param["IsModifiable"] is True
+                # Strip rds internal params to try and fit within 20 param limit
+                # See https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-dbparametergroup.html#cfn-rds-dbparametergroup-parameters
+                and not param["ParameterName"].startswith('rds.')
             ):
                 params_return[param["ParameterName"]] = param["ParameterValue"]
             if param["ParameterName"] == "binlog_format":


### PR DESCRIPTION
DB(Cluster)ParameterGroups may have at most 20 parameters. This makes it impossible to copy a parameter group which has more than this, such as aurora-postgresql12. As a workaround, strip any internal RDS parameters on the assumption the default is probably fine there.

See https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-dbparametergroup.html#cfn-rds-dbparametergroup-parameters