### PR TITLE
Adds deploy label ecs.compute.platform to override from FARGATE

### DIFF
--- a/docs/syntax/compose_x/ecs.details/deploy.rst
+++ b/docs/syntax/compose_x/ecs.details/deploy.rst
@@ -58,7 +58,6 @@ For example, you would have:
 
 .. literalinclude:: ../../../../use-cases/blog.features.yml
     :language: yaml
-    :emphasize-lines: 30-31, 83-85
 
 .. warning::
 
@@ -113,4 +112,92 @@ beyond the free 20GB coming by default.
     This parameter only when using Fargate. This will be ignored when using EC2 or EXTERNAL deployment modes.
     For more storage using EC2, provide more local storage for your EC2 nodes.
 
+ecs.compute.platform
+^^^^^^^^^^^^^^^^^^^^^^
+
+This setting allows you to define which compute platform to deploy your services onto. This is useful if you
+have cluster that has a mix of EC2 capacity (default behaviour) and Fargate ones.
+This can also allow you to define to deploy your container to ECS Anywhere (using EXTERNAL mode).
+
++----------------+----------------------+
+| label          | ecs.compute.platform |
++----------------+----------------------+
+| Allowed Values | * EC2                |
+|                | * FARGATE            |
+|                | * EXTERNAL           |
++----------------+----------------------+
+
+.. hint::
+
+    By default, ECS Clusters created with ECS Compose-X will use AWS Fargate as the compute platform.
+
+.. hint::
+
+    If you created your cluster without providing any Capacity Providers, Fargate cannot work.
+    Compose-X, when using x-cluster.Lookup will attempt to determine whether the Fargate capacity providers
+    are present, and if not, override to EC2 **for all services**
+
+.. tip::
+
+    Below two ECS Clusters, one created via CLI without any arguments, the other created in the AWS Console.
+
+    .. code-block:: bash
+        :caption: ECS cluster created without capacity providers
+
+        aws ecs create-cluster --cluster-name testing
+        {
+            "cluster": {
+                "clusterArn": "arn:aws:ecs:eu-west-1:2111111111111:cluster/testing",
+                "clusterName": "testing",
+                "status": "ACTIVE",
+                "registeredContainerInstancesCount": 0,
+                "runningTasksCount": 0,
+                "pendingTasksCount": 0,
+                "activeServicesCount": 0,
+                "statistics": [],
+                "tags": [],
+                "settings": [
+                    {
+                        "name": "containerInsights",
+                        "value": "enabled"
+                    }
+                ],
+                "capacityProviders": [],
+                "defaultCapacityProviderStrategy": []
+            }
+        }
+
+    .. code-block:: json
+        :caption: Cluster created in the AWS Console which automatically adds FARGATE providers
+
+        [
+          {
+            "clusterArn": "arn:aws:ecs:eu-west-1:211111111111:cluster/testinginconsole",
+            "clusterName": "testinginconsole",
+            "status": "ACTIVE",
+            "registeredContainerInstancesCount": 0,
+            "runningTasksCount": 0,
+            "pendingTasksCount": 0,
+            "activeServicesCount": 0,
+            "statistics": [],
+            "tags": [],
+            "settings": [
+              {
+                "name": "containerInsights",
+                "value": "enabled"
+              }
+            ],
+            "capacityProviders": [
+              "FARGATE_SPOT",
+              "FARGATE"
+            ],
+            "defaultCapacityProviderStrategy": []
+          }
+        ]
+
+    .. seealso::
+
+        `Add CapacityProviders via the CLI`_
+
 .. _Dependency reference for more information: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-containerdependency.html
+.. _Add CapacityProviders via the CLI: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/fargate-capacity-providers.html#fargate-capacity-providers-existing-cluster

--- a/ecs_composex/common/compose_services.py
+++ b/ecs_composex/common/compose_services.py
@@ -1041,7 +1041,6 @@ class ComposeService(object):
             self.compute_platform = deployment[labels][compute_key]
             LOG.info(f"{self.name} set ecs.compute.platform to {self.compute_platform}")
 
-
     def define_start_condition(self, deployment):
         """
         Method to define the start condition success for the container
@@ -1365,6 +1364,7 @@ class ComposeFamily(object):
 
     def refresh(self):
         self.sort_container_configs()
+        self.set_compute_platform()
         self.handle_iam()
         self.handle_logging()
         self.apply_services_params()
@@ -1382,7 +1382,6 @@ class ComposeFamily(object):
                     if service_depends_on not in self.services_depends_on:
                         self.services_depends_on.append(service_depends_on)
 
-<<<<<<< HEAD
     def set_task_ephemeral_storage(self):
         """
         If any service ephemeral storage is defined above, sets the ephemeral storage to the maximum of them.
@@ -1390,7 +1389,7 @@ class ComposeFamily(object):
         max_storage = max([service.ephemeral_storage for service in self.services])
         if max_storage >= 21:
             self.task_ephemeral_storage = max_storage
-=======
+
     def set_compute_platform(self):
         """
         Iterates over all services and if ecs.compute.platform
@@ -1422,7 +1421,6 @@ class ComposeFamily(object):
                         self.stack.Parameters.update(
                             {ecs_params.LAUNCH_TYPE: self.compute_platform}
                         )
->>>>>>> d4bdcb7 (Adds deploy label ecs.compute.platform to override from FARGATE)
 
     def set_xray(self):
         """

--- a/ecs_composex/common/compose_services.py
+++ b/ecs_composex/common/compose_services.py
@@ -1914,7 +1914,7 @@ class ComposeFamily(object):
             TaskRoleArn=GetAtt(TASK_ROLE_T, "Arn"),
             ExecutionRoleArn=GetAtt(EXEC_ROLE_T, "Arn"),
             ContainerDefinitions=[s.container_definition for s in self.services],
-            RequiresCompatibilities=["EC2", "FARGATE"],
+            RequiresCompatibilities=["EC2", "FARGATE", "EXTERNAL"],
             Tags=Tags(
                 {
                     "Name": Ref(ecs_params.SERVICE_NAME),

--- a/ecs_composex/common/compose_services.py
+++ b/ecs_composex/common/compose_services.py
@@ -1030,7 +1030,6 @@ class ComposeService(object):
         """
         compute_key = "ecs.compute.platform"
         labels = "labels"
-        print(deployment)
         allowed_values = ["EC2", "FARGATE", "EXTERNAL"]
         if keyisset(labels, deployment) and keyisset(compute_key, deployment[labels]):
             if not deployment[labels][compute_key] in allowed_values:
@@ -1040,7 +1039,7 @@ class ComposeService(object):
                     allowed_values,
                 )
             self.compute_platform = deployment[labels][compute_key]
-            print(self.name, self.compute_platform)
+            LOG.info(f"{self.name} set ecs.compute.platform to {self.compute_platform}")
 
 
     def define_start_condition(self, deployment):

--- a/ecs_composex/common/files.py
+++ b/ecs_composex/common/files.py
@@ -210,10 +210,15 @@ class FileArtifact(object):
                 pp.pprint(self.template.to_dict())
                 raise error
         elif isinstance(self.content, (list, dict, tuple)):
-            if self.mime == YAML_MIME:
-                self.body = yaml.dump(self.content, Dumper=Dumper)
-            elif self.mime == JSON_MIME:
-                self.body = json.dumps(self.content, indent=4)
+            try:
+                if self.mime == YAML_MIME:
+                    self.body = yaml.dump(self.content, Dumper=Dumper)
+                elif self.mime == JSON_MIME:
+                    self.body = json.dumps(self.content, indent=4)
+            except Exception as error:
+                pp = pprint.PrettyPrinter(indent=2)
+                pp.pprint(self.content)
+                raise error
 
     def define_file_specs(self, file_name, file_format, settings):
         """

--- a/ecs_composex/common/settings.py
+++ b/ecs_composex/common/settings.py
@@ -172,6 +172,7 @@ class ComposeXSettings(object):
         self.evaluate_private_namespace()
         self.name = kwargs[self.name_arg]
         self.ecs_cluster = None
+        self.ecs_cluster_platform_override = None
         self.ignore_ecr_findings = keyisset(self.ecr_arg, kwargs)
 
     def evaluate_private_namespace(self):

--- a/ecs_composex/ecs/ecs_cluster.py
+++ b/ecs_composex/ecs/ecs_cluster.py
@@ -150,6 +150,17 @@ def import_from_x_aws_cluster(compose_content):
     compose_content[RES_KEY] = {"Use": cluster_name}
 
 
+def define_cluster_lookup_props(cluster_r, settings):
+    cluster_mapping = {}
+    if not cluster_r:
+        return cluster_mapping
+    if cluster_r[0]:
+        cluster_mapping = {CLUSTER_NAME.title: {"Name": cluster_r[0]}}
+    if cluster_r[1] is not None:
+        settings.ecs_cluster_platform_override = cluster_r[1]
+    return cluster_mapping
+
+
 def add_ecs_cluster(root_stack, settings):
     """
     Function to create the ECS Cluster.
@@ -177,10 +188,7 @@ def add_ecs_cluster(root_stack, settings):
             cluster_r = lookup_ecs_cluster(
                 settings.session, settings.compose_content[RES_KEY]["Lookup"]
             )
-            if cluster_r[0]:
-                cluster_mapping = {CLUSTER_NAME.title: {"Name": cluster_r[0]}}
-            if cluster_r[1] is not None:
-                settings.ecs_cluster_platform_override = cluster_r[1]
+            cluster_mapping = define_cluster_lookup_props(cluster_r, settings)
         elif keyisset("Properties", settings.compose_content[RES_KEY]):
             cluster = define_cluster(settings.compose_content[RES_KEY])
             root_stack.stack_template.add_resource(cluster)

--- a/ecs_composex/ecs/ecs_params.py
+++ b/ecs_composex/ecs/ecs_params.py
@@ -33,7 +33,7 @@ LAUNCH_TYPE_T = "EcsLaunchType"
 LAUNCH_TYPE = Parameter(
     LAUNCH_TYPE_T,
     Type="String",
-    AllowedValues=["EC2", "FARGATE"],
+    AllowedValues=["EC2", "FARGATE", "EXTERNAL"],
     Default="FARGATE",
 )
 

--- a/ecs_composex/ecs/ecs_service.py
+++ b/ecs_composex/ecs/ecs_service.py
@@ -436,9 +436,9 @@ class Service(object):
                 ecs_conditions.USE_FARGATE_CON_T,
                 "REPLICA",
                 If(
-                    ecs_conditions.SERVICE_COUNT_ZERO_AND_FARGATE_CON_T,
-                    "REPLICA",
+                    ecs_conditions.SERVICE_COUNT_ZERO_CON_T,
                     "DAEMON",
+                    "REPLICA",
                 ),
             ),
             PlacementStrategies=If(

--- a/ecs_composex/ecs/ecs_service.py
+++ b/ecs_composex/ecs/ecs_service.py
@@ -465,7 +465,11 @@ class Service(object):
                 }
             ),
             PropagateTags="SERVICE",
-            PlatformVersion=Ref(ecs_params.FARGATE_VERSION),
+            PlatformVersion=If(
+                ecs_conditions.USE_FARGATE_CON_T,
+                Ref(ecs_params.FARGATE_VERSION),
+                Ref(AWS_NO_VALUE),
+            ),
             **attrs,
         )
         family.service_definition = self.ecs_service

--- a/ecs_composex/ecs/ecs_stack.py
+++ b/ecs_composex/ecs/ecs_stack.py
@@ -60,6 +60,11 @@ def associate_services_to_root_stack(root_stack, settings, vpc_stack=None):
                 ),
             }
         )
+        if settings.ecs_cluster_platform_override:
+            family.compute_platform = settings.ecs_cluster_platform_override
+            family.stack.Parameters.update(
+                {ecs_params.LAUNCH_TYPE.title: settings.ecs_cluster_platform_override}
+            )
         if not vpc_stack:
             family.stack.no_vpc_parameters(settings)
         else:

--- a/ecs_composex/ecs/ecs_template.py
+++ b/ecs_composex/ecs/ecs_template.py
@@ -208,6 +208,7 @@ def generate_services(settings):
                 ecs_params.SERVICE_NAME_T: family.logical_name,
                 CLUSTER_NAME_T: Ref(CLUSTER_NAME),
                 ROOT_STACK_NAME_T: Ref(ROOT_STACK_NAME),
+                ecs_params.LAUNCH_TYPE.title: family.compute_platform,
             }
         )
         family.upload_services_env_files(settings)

--- a/use-cases/mixed_computes/only_ec2.yaml
+++ b/use-cases/mixed_computes/only_ec2.yaml
@@ -1,0 +1,60 @@
+---
+version: "3.7"
+
+x-cluster:
+  Lookup: dev
+
+services:
+  session-cache:
+    image: redis:6.0.5-alpine
+    deploy:
+      labels:
+        ecs.compute.platform: EC2
+    ports:
+    - 6349:6349
+
+  frontend:
+    image: ${REGISTRY_URI}frontend:${TAG:-latest}
+    ports:
+      - protocol: tcp
+        target: 80
+    build:
+      context: .
+      dockerfile: Dockerfile
+    deploy:
+      resources:
+        limits:
+          cpus: 0.5
+          memory: 256MB
+        reservations:
+          cpus: 0.1
+          memory: 128MB
+      labels:
+        ecs.compute.platform: EC2
+    x-ecr:
+      InterpolateWithDigest: true
+
+
+x-dns:
+  PublicZone:
+    Name: mydomain.net
+  PrivateNamespace:
+    Name: cluster.internal
+
+
+x-elbv2:
+  public-alb:
+    Properties:
+      Scheme: internet-facing
+      Type: application
+    Services:
+      - name: frontend:frontend
+        port: 80
+        protocol: HTTP
+        healthcheck: 80:HTTP:/:200,201
+    Listeners:
+      - Port: 80
+        Protocol: HTTP
+        Targets:
+          - name: frontend:frontend
+            access: /

--- a/use-cases/mixed_computes/only_ec2.yaml
+++ b/use-cases/mixed_computes/only_ec2.yaml
@@ -1,9 +1,6 @@
 ---
 version: "3.7"
 
-x-cluster:
-  Lookup: dev
-
 services:
   session-cache:
     image: redis:6.0.5-alpine


### PR DESCRIPTION
Addresses #499 

* ECS Cluster Lookup will look for FARGATE/FARGATE_SPOT in capacity providers. If not set (old clusters predating capacity provides defaults), overrides to EC2 for ALL services
* Added condition that only if `EcsLaunchType` is set to `FARGATE` will the Platform version will be set
* Added new docker deploy label that allows to explicitely override the compute type to EC2/FARGATE/EXTERNAL. When using a multi-services "family", any service defined to anything not FARGATE overrides it for all other containers in the task family.

