### PR TITLE
Re-instating default PrivateNamespace to support all DNS features

### DIFF
--- a/ecs_composex/dns/__init__.py
+++ b/ecs_composex/dns/__init__.py
@@ -1,4 +1,4 @@
-﻿#  -*- coding: utf-8 -*-
+#  -*- coding: utf-8 -*-
 # SPDX-License-Identifier: MPL-2.0
 # Copyright 2020-2021 John Mille <john@compose-x.io>
 
@@ -238,13 +238,8 @@ class DnsSettings(object):
         )
 
         if not dns_settings and not settings.requires_private_namespace:
-            LOG.warning(
-                f"No {self.main_key} defined and no mesh nor service registry defined. Skipping"
-            )
-            return
-        elif not dns_settings and settings.requires_private_namespace:
             LOG.info(
-                f"No {self.main_key} defined but a private namespace is required. Using default"
+                f"No x-dns.PrivateNamespace defined. Adding default one for AppMesh and other DNS based features."
             )
             dns_settings = {PrivateNamespace.key: {"Name": self.default_private_name}}
 

--- a/ecs_composex/vpc/vpc_stack.py
+++ b/ecs_composex/vpc/vpc_stack.py
@@ -1,4 +1,4 @@
-﻿#  -*- coding: utf-8 -*-
+#  -*- coding: utf-8 -*-
 # SPDX-License-Identifier: MPL-2.0
 # Copyright 2020-2021 John Mille <john@compose-x.io>
 
@@ -201,15 +201,6 @@ def import_vpc_settings(vpc_settings):
     set_subnets_from_use(extra_subnets, vpc_settings, settings)
 
     return settings
-
-
-def create_vpc_mapping(settings_params):
-    """
-    Function to create a CFN Mapping to use and assign subnets to substacks
-
-    :param settings_params:
-    :return:
-    """
 
 
 def apply_vpc_settings(x_settings, root_stack, settings):


### PR DESCRIPTION
For many features, DNS is necessary. Used to add one by default, re-instating that as missing x-dns.PrivateNamespace can lead to advert issues.