### PR TITLE
Fixed x-alarms to x-elbv2

### DIFF
--- a/ecs_composex/alarms/alarms_elbv2.py
+++ b/ecs_composex/alarms/alarms_elbv2.py
@@ -110,9 +110,9 @@ def validate_tgt_input(dimension, settings):
             "Got",
             parts,
         )
-    if parts.group("svc") not in settings.families.keys():
+    if parts.group("svc") not in [_.name for _ in settings.families.values()]:
         raise ValueError(
-            f"the service {parts.group('svc')} not in the defined services",
+            f"alarms - Service {parts.group('svc')} not in the defined services",
             settings.families.keys(),
         )
     return parts
@@ -134,7 +134,16 @@ def handle_elbv2_target_group_dimensions(alarms_stack, dimension, resource, sett
         )
         return
     parts = validate_tgt_input(dimension, settings)
-    family = settings.families[parts.group("svc")]
+    for family in settings.families.values():
+        if family.name == parts.group("svc"):
+            break
+    else:
+        raise KeyError(
+            "alarms. unable to find services family",
+            parts.group("svc"),
+            "service families available",
+            [_.name for _ in settings.families.values()],
+        )
     port = int(parts.group("port"))
     the_tgt = None
     the_lb = get_target_lb(parts, dimension, resource, settings)

--- a/ecs_composex/alarms/alarms_stack.py
+++ b/ecs_composex/alarms/alarms_stack.py
@@ -220,12 +220,14 @@ class Alarm(ServicesXResource):
         if namespace == "AWS/ApplicationELB" or namespace == "AWS/NetworkELB":
             for dimension in dimensions:
                 if dimension.Name == "LoadBalancer" and dimension.Value.startswith(
-                    "x-elbv2::"
+                    r"x-elbv2::"
                 ):
                     handle_elbv2_dimension_mapping(
                         self.stack, dimension, self, settings
                     )
-                elif dimension.Name == "TargetGroup":
+                elif dimension.Name == "TargetGroup" and dimension.Value.startswith(
+                    r"x-elbv2::"
+                ):
                     handle_elbv2_target_group_dimensions(
                         self.stack, dimension, self, settings
                     )

--- a/ecs_composex/elbv2/elbv2_stack.py
+++ b/ecs_composex/elbv2/elbv2_stack.py
@@ -1023,7 +1023,7 @@ class Elbv2(NetworkXResource):
         :rtype: str
         """
         if self.subnets_override:
-            if not self.parameters["Subnets"] in vpc_stack.vpc_resource.mappings.keys():
+            if self.subnets_override not in vpc_stack.vpc_resource.mappings.keys():
                 raise KeyError(
                     f"The subnets indicated for {self.name} is not valid. Valid ones are",
                     vpc_stack.vpc_resource.mappings.keys(),


### PR DESCRIPTION
Ignoring TargetGroup when not starting with `x-elbv2` and leaving the value as-is.