### PR TITLE
Expose env vars as parameters to the stack

### DIFF
--- a/ecs_composex/compose/compose_services/__init__.py
+++ b/ecs_composex/compose/compose_services/__init__.py
@@ -160,6 +160,7 @@ class ComposeService:
         self.set_container_definition()
         self.links = set_else_none("links", definition)
         self.family_links: list = []
+        self.x_environment: dict = set_else_none("x-environment", definition, {})
 
     def __repr__(self):
         return self.name

--- a/ecs_composex/ecs/ecs_family/__init__.py
+++ b/ecs_composex/ecs/ecs_family/__init__.py
@@ -656,6 +656,17 @@ class ComposeFamily:
 
         validate_compute_configuration_for_task(self, settings)
 
+    def x_environment_processing(self):
+        """
+        Checks for each service if `x-environment` was set
+        """
+        from .family_helpers import swap_environment_value_with_parameter
+
+        for service in self.ordered_services:
+            if not service.x_environment:
+                continue
+            swap_environment_value_with_parameter(self, service)
+
 
 class ServiceStack(ComposeXStack):
     """

--- a/ecs_composex/ecs_composex.py
+++ b/ecs_composex/ecs_composex.py
@@ -303,6 +303,7 @@ def generate_full_template(settings: ComposeXSettings):
         family.finalize_family_settings()
         map_resource_return_value_to_services_command(family, settings)
         family.state_facts()
+        family.x_environment_processing()
 
     set_ecs_cluster_identifier(settings.root_stack, settings)
     add_all_tags(settings.root_stack.stack_template, settings)

--- a/ecs_composex/specs/compose-spec.json
+++ b/ecs_composex/specs/compose-spec.json
@@ -102,6 +102,9 @@
         "x-docker_opts": {
           "$ref": "services.x-docker_opts.spec.json"
         },
+        "x-environment": {
+          "$ref": "services.x-environment.spec.json"
+        },
         "x-prometheus": {
           "$ref": "services.x-prometheus.spec.json"
         },

--- a/ecs_composex/specs/services.x-environment.spec.json
+++ b/ecs_composex/specs/services.x-environment.spec.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "id": "services.x-environment",
+  "$id": "services.x-environment.spec.json",
+  "type": "object",
+  "title": "services.x-environment specification",
+  "description": "The services.x-environment specification for ComposeX",
+  "additionalProperties": false,
+  "required": [
+    "SetAsParameter"
+  ],
+  "properties": {
+    "SetAsParameter": {
+      "oneOf": [
+        {
+          "type": "object",
+          "minProperties": 1,
+          "additionalProperties": false,
+          "patternProperties": {
+            "^x-": {},
+            "^[a-zA-Z0-9_]+$": {
+              "type": "object"
+            }
+          }
+        },
+        {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string"
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
tested with
```yaml
services:
  proxy:
    image: nginx
    environment:
      ENV_var01: something
      ENV_VAR_01: else
      env_VAR02: hello
      ENVVAR02: world
      PXY_ANumber: 10
    x-environment:
      SetAsParameter:
        - ENV_var01
        - ENV_VAR_01
        - env_VAR02
        - ENVVAR02
        - DOES_NOT_EXIST
        - PXY_ANumber
  backend:
    image: nginx
    environment:
      ENV_var01: 1
      ENV_VAR_01: else
      env_VAR02: hello
      ENVVAR02: world
    x-environment:
      SetAsParameter:
        ENV_var01:
          Type: Number
        ENV_VAR_01:
          Type: String
        env_VAR02:
          Type: CommaDelimitedList
          Description: Something totally useful
        ENVVAR02:
          Type: String
          AllowedPattern: '^[\w]+$'
        DOES_NOT_EXIST:
          Type: WhateverTheWeather
```
