### PR TITLE
Fix missing ingress.SG AccountOwner parameter

### DIFF
--- a/docs/syntax/compose_x/ecs.details/network.rst
+++ b/docs/syntax/compose_x/ecs.details/network.rst
@@ -77,10 +77,17 @@ Ingress Syntax reference
                 Id: pl-abcd
             Myself: True/False
 
-.. note::
+.. tip::
 
-    Future feature is to allow to input a security group ID and the remote account ID to allow ingress traffic from
-    a security group owned by another of your account (or 3rd party).
+    You can define the SG from another AWS account by setting ``AccountOwner`` in the Security group definition.
+
+.. tip::
+
+    You can define which ports to open per source using the ``Ports`` list.
+
+    .. hint::
+
+        If you enter a port number that is not in the ``Ports`` list, it will be ignored.
 
 .. hint::
 

--- a/ecs_composex/__init__.py
+++ b/ecs_composex/__init__.py
@@ -5,4 +5,4 @@
 
 __author__ = """John Preston"""
 __email__ = "john@compose-x.io"
-__version__ = "0.23.27-rc1"
+__version__ = "0.23.27-rc2"

--- a/ecs_composex/ingress_settings.py
+++ b/ecs_composex/ingress_settings.py
@@ -288,7 +288,9 @@ class Ingress:
                         SecurityGroupIngress(
                             f"From{NONALPHANUM.sub('', sg_id)}ToServiceOn{target_port}",
                             SourceSecurityGroupId=sg_id,
-                            SourceSecurityGroupOwnerId=Ref(AWS_ACCOUNT_ID),
+                            SourceSecurityGroupOwnerId=set_else_none(
+                                "AccountOwner", source, Ref(AWS_ACCOUNT_ID)
+                            ),
                             **common_args,
                         )
                     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ecs_composex"
-version = "0.23.27-rc1"
+version = "0.23.27-rc2"
 description = "Manage, Configure and Deploy your services and AWS services and applications from your docker-compose definition"
 authors = ["John Preston <john@compose-x.io>"]
 maintainers = ["John Preston <john@compose-x.io>"]
@@ -82,7 +82,7 @@ sphinx-material = "^0.0.35"
 github_url = "https://github.com/compose-x/ecs_composex"
 
 [tool.tbump.version]
-current = "0.23.27-rc1"
+current = "0.23.27-rc2"
 regex = '''
   (?P<major>\d+)
   \.


### PR DESCRIPTION
Fixes that `AccountOwner` is not taken into account creating Security Ingress rules allowing other SGs from other account to access the service.