### PR TITLE
Optional parameters 'apply' and 'cleanup' for the 'plan' cli command

### DIFF
--- a/ecs_composex/cli.py
+++ b/ecs_composex/cli.py
@@ -153,6 +153,20 @@ def main_parser():
     parser.add_argument(
         "--loglevel", type=str, help="Log level. Defaults to INFO", required=False
     )
+    base_command_parser.add_argument(
+        "--apply",
+        dest="apply",
+        help="Whether to apply the change-set automatically (True/False).",
+        required=False,
+        type=bool,
+    )
+    base_command_parser.add_argument(
+        "--cleanup",
+        dest="cleanup",
+        help="Whether to cleanup the change-set automatically (True/False).",
+        required=False,
+        type=bool,
+    )
     for command in ComposeXSettings.active_commands:
         cmd_parsers.add_parser(
             name=command["name"],
@@ -216,7 +230,7 @@ def main():
     if settings.deploy:
         deploy(settings, root_stack)
     elif settings.plan:
-        plan(settings, root_stack)
+        plan(settings, root_stack, apply=args.apply, cleanup=args.cleanup)
     return 0
 
 

--- a/ecs_composex/common/aws.py
+++ b/ecs_composex/common/aws.py
@@ -381,11 +381,13 @@ def get_change_set_status(client, change_set_name, settings):
     return status
 
 
-def plan(settings, root_stack):
+def plan(settings, root_stack, apply=None, cleanup=None):
     """
     Function to create a recursive change-set and return diffs
     :param ComposeXSettings settings:
     :param ComposeXStack root_stack:
+    :param apply: Optional[bool] - Whether to apply the change-set (True/False). Default is None (prompt user).
+    :param cleanup: Optional[bool] - Whether to clean up the change-set (True/False). Default is None (prompt user).
     :return:
     """
     validate_stack_availability(settings, root_stack)
@@ -408,14 +410,20 @@ def plan(settings, root_stack):
         )
         status = get_change_set_status(client, change_set_name, settings)
         if status:
-            apply_q = input("Want to apply? [yN]: ")
-            if apply_q in ["y", "Y", "YES", "Yes", "yes"]:
+            if apply is None:
+                apply_q = input("Want to apply? [yN]: ")
+                apply = apply_q.lower() in ["y", "yes"]
+
+            if apply:
                 client.execute_change_set(
                     ChangeSetName=change_set_name,
                     StackName=settings.name,
                     DisableRollback=settings.disable_rollback,
                 )
             else:
-                delete_q = input("Cleanup ChangeSet ? [yN]: ")
-                if delete_q in ["y", "Y", "YES", "Yes", "yes"]:
+                if cleanup is None:
+                    delete_q = input("Cleanup ChangeSet ? [yN]: ")
+                    cleanup = delete_q.lower() in ["y", "yes"]
+
+                if cleanup:
                     client.delete_stack(StackName=settings.name)


### PR DESCRIPTION
Added optional parameters 'apply' and 'cleanup' for the 'plan' CLI command.

When either 'apply' or 'cleanup' is not present, it will work like before and require user input for that option.

The main use case for this is in CI/CD pipelines where shell interactivity is usually not present and a reviewer can view the changes from the plan command directly.